### PR TITLE
switch MortalitySmooth to remote ref

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: ungroup
 Type: Package
 Title: Penalized Composite Link Model for Efficient Estimation of 
  Smooth Distributions from Coarsely Binned Data
-Version: 1.1.5
+Version: 1.1.6
 Authors@R: c(
   person("Marius D.", "Pascariu", role = c("aut", "cre"), email = "rpascariu@outlook.com", comment = c(ORCID = "0000-0002-2568-6489")),
   person("Silvia", "Rizzi", role = "aut", email = "srizzi@health.sdu.dk"),
@@ -46,3 +46,4 @@ URL: https://github.com/mpascariu/ungroup
 BugReports: https://github.com/mpascariu/ungroup/issues
 VignetteBuilder: knitr
 RoxygenNote: 6.1.1
+Remotes: https://github.com/timriffe/MortalitySmooth


### PR DESCRIPTION
See emails on `svcm` and `MortalitySmooth` for more context: This just switches the `MortalitySmooth` reference to my github fork. The `MortalitySmooth` version differs only in that its `svcm` dependency is removed: the function has been copied into the package, as GC intended to do. I did not run `checks()`, because many other files are modified and I don't want to commit unrelated changes at this time. This minimal change should make `ungroup` viable again I think.